### PR TITLE
Webpack5 changes

### DIFF
--- a/lib/webpack-plugin.js
+++ b/lib/webpack-plugin.js
@@ -178,7 +178,7 @@ class IsomorphicLoaderPlugin {
       saveConfig("invalid");
     });
 
-    compiler.hooks.invalid.tap(pluginName, () => {
+    compiler.hooks.done.tap(pluginName, () => {
       saveConfig("done");
     });
   }

--- a/lib/webpack-plugin.js
+++ b/lib/webpack-plugin.js
@@ -127,7 +127,8 @@ class IsomorphicLoaderPlugin {
       return config;
     };
 
-    compiler.plugin("make", (compilation, callback) => {
+    const pluginName = "IsomorphicLoader";
+    compiler.hooks.make.tap(pluginName, () => {
       this.config = createConfig(compiler.options);
 
       // If running in webpack dev server mode, then create a config file ASAP so not to leave
@@ -136,11 +137,9 @@ class IsomorphicLoaderPlugin {
       if (this.config.isWebpackDev) {
         saveConfig("webpackdev make");
       }
-
-      callback();
     });
 
-    compiler.plugin("emit", (compilation, callback) => {
+    compiler.hooks.emit.tap(pluginName, compilation => {
       let sigIdx;
       const stats = compilation.getStats().toJson();
       const loaderSig = "isomorphic-loader";
@@ -176,12 +175,12 @@ class IsomorphicLoaderPlugin {
       callback();
     });
 
-    compiler.plugin("invalid", () => {
+    compiler.hooks.invalid.tap(pluginName, () => {
       this.config.valid = false;
       saveConfig("invalid");
     });
 
-    compiler.plugin("done", () => {
+    compiler.hooks.invalid.tap(pluginName, () => {
       saveConfig("done");
     });
   }

--- a/lib/webpack-plugin.js
+++ b/lib/webpack-plugin.js
@@ -171,8 +171,6 @@ class IsomorphicLoaderPlugin {
       config.assetsFile = Path.join(config.output.path, this.options.assetsFile);
 
       this.config = config;
-
-      callback();
     });
 
     compiler.hooks.invalid.tap(pluginName, () => {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "fetch": "^1.0.1",
     "file-loader": "^1.0.0",
     "rimraf": "^2.5.2",
-    "webpack": "^3",
-    "webpack-dev-server": "^2",
-    "webpack4": "./test/webpack4"
+    "webpack": "^4",
+    "webpack-dev-server": "^3",
+    "webpack5": "./test/webpack5"
   },
   "nyc": {
     "all": true,

--- a/test/lib/webpack-info.js
+++ b/test/lib/webpack-info.js
@@ -3,17 +3,17 @@
 const testInfo = {
   v4: {
     skip: false,
-    xrequire: require("webpack4/xrequire"),
-    webpack: "webpack",
-    devServer: "webpack-dev-server",
-    config: require.resolve("../webpack4.config")
-  },
-  v3: {
-    skip: false,
     xrequire: require,
     webpack: "webpack",
     devServer: "webpack-dev-server",
     config: require.resolve("../webpack.config")
+  },
+  v5: {
+    skip: false,
+    xrequire: require,
+    webpack: "webpack",
+    devServer: "webpack-dev-server",
+    config: require.resolve("../webpack5/config")
   }
 };
 

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -16,11 +16,11 @@ module.exports = {
     rules: [
       {
         test: /\.(jpe?g|png|gif|svg)$/i,
-        use: [{ loader: "electrode-cdn-file-loader", options: { limit: 10000 } }, "../.."]
+        loader: "file-loader!../.."
       },
       {
         test: /\.(ttf|eot)$/,
-        use: [{ loader: "electrode-cdn-file-loader", options: { limit: 10000 } }, "../.."]
+        loader: "file-loader!../.."
       }
     ]
   }

--- a/test/webpack4/xrequire.js
+++ b/test/webpack4/xrequire.js
@@ -1,1 +1,0 @@
-module.exports = require;

--- a/test/webpack5/config.js
+++ b/test/webpack5/config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const IsomorphicLoaderPlugin = require("../lib/webpack-plugin");
+const IsomorphicLoaderPlugin = require("../../lib/webpack-plugin");
 const Path = require("path");
 
 module.exports = {

--- a/test/webpack5/package.json
+++ b/test/webpack5/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "webpack4",
+  "name": "webpack5",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
   },
   "dependencies": {
-    "webpack": "^4",
-    "webpack-cli": "^2",
+    "webpack": "^5.0.0-beta.13",
+    "webpack-cli": "^4.0.0-beta.6",
     "webpack-dev-server": "^3"
   },
   "private": true


### PR DESCRIPTION
1. Adopting completely to the breaking changes introduced in Webpack v4 
   (as they're mandatory for v5)

2. Update unit tests to support Webpack versions v4 & v5